### PR TITLE
Ch27

### DIFF
--- a/ch27.html
+++ b/ch27.html
@@ -48,7 +48,7 @@
 
             <p>For example, one solution to avoid a race condition is to ensure that only one thread at a time can access the code that causes the problem; a process known as <i>synchronizing</i> that block of code.</p>
 
-            <p>Synchronization works with locks. Every object comes with a built-in lock and since there is only lock per object, only one thread can hold that lock at any time. The other threads can only take the lock until the first thread release it. Meanwhile, they are blocked.</p>
+            <p>Synchronization works with locks. Every object comes with a built-in lock and since there is only lock per object, only one thread can hold that lock at any time. The other threads cannot take the lock until the first thread releases it. Meanwhile, they are blocked.</p>
 
             <p>You acquire a lock by using the <code>synchronized</code> keyword in either a block or a method.</p>
 

--- a/ch27.html
+++ b/ch27.html
@@ -355,7 +355,7 @@
 
             <p><b>ConcurrentNavigableMap</b><br /> It represents a thread-safe <code>NavigableMap</code> (like <code>TreeSet</code>) and is implemented by the <code>ConcurrentSkipListMap</code> class, sorted according to the natural ordering of its keys, or by a <code>Comparator</code> provided in its constructor.</p>
 
-            <p>A <code>ConcurrentNavigable</code> also implements <code>Map</code> and <code>ConcurrentMap</code>, so it has methods like <code>computeIfAbsent()</code>, <code>getOrDefault()</code>, etc.</p>
+            <p>A <code>ConcurrentNavigableMap</code> also implements <code>Map</code> and <code>ConcurrentMap</code>, so it has methods like <code>computeIfAbsent()</code>, <code>getOrDefault()</code>, etc.</p>
 
             <p><b>CopyOnWriteArrayList</b><br /> It represents a thread-safe <code>List</code>, similar to an <code>ArrayList</code>, but when it's modified (with methods like <code>add()</code> or <code>set()</code>), a new copy of the underlying array is created (hence the name).</p>
 

--- a/ch27.html
+++ b/ch27.html
@@ -44,7 +44,7 @@
 
             <h2>Synchronization</h2>
 
-            <p>In the last chapter, we reviewed some problems that can happen in a concurrent environment and briefly talked about how locking.</p>
+            <p>In the last chapter, we reviewed some problems that can happen in a concurrent environment and briefly talked about locking.</p>
 
             <p>For example, one solution to avoid a race condition is to ensure that only one thread at a time can access the code that causes the problem, that's known as synchronizing that block of code.</p>
 

--- a/ch27.html
+++ b/ch27.html
@@ -121,7 +121,7 @@
 	  &nbsp; &nbsp; }<br />
 	  }</code></p>
 
-            <p>By looking at one possible output, we can see that we have a race condition problem because five threads are executing the same code:</p>
+            <p>By looking at one possible output, we can see that we have a race condition problem because four threads are executing the same code:</p>
 
             <p><code class="hljs">2<br />
 	  2<br />

--- a/ch27.html
+++ b/ch27.html
@@ -403,7 +403,7 @@
 
             <p>Also, they throw an exception if they are modified within an iteration.</p>
 
-            <p>Only use these methods if you have to work with an existing collection in a concurrent environment (otherwise create since the beginning a <code>java.util.concurrent</code> collection).</p>
+            <p>Only use these methods if you have to work with an existing collection in a concurrent environment (otherwise, from the beginning, use a <code>java.util.concurrent</code> collection).</p>
 
             <h2>CyclicBarrier</h2>
 

--- a/ch27.html
+++ b/ch27.html
@@ -229,7 +229,7 @@
                 <li><code>CopyOnWriteArrayList</code> (for lists)</li>
             </ul>
 
-            <p>Since these interfaces extends from the <code>java.util</code> collection interfaces, they inherit the methods we already know (and behave like one them) so here you'll only find the added methods that support concurrency.</p>
+            <p>Since these interfaces extends from the <code>java.util</code> collection interfaces, they inherit the methods we already know (and behave like one of them) so here you'll only find the added methods that support concurrency.</p>
 
             <p><b>BlockingQueue</b><br /> It represents a thread-safe queue that waits (with an optional timeout) for an element to be inserted if the queue is empty or for an element to be removed if the queue is full:</p>
 

--- a/ch27.html
+++ b/ch27.html
@@ -46,7 +46,7 @@
 
             <p>In the last chapter, we reviewed some problems that can happen in a concurrent environment and briefly talked about locking.</p>
 
-            <p>For example, one solution to avoid a race condition is to ensure that only one thread at a time can access the code that causes the problem, that's known as synchronizing that block of code.</p>
+            <p>For example, one solution to avoid a race condition is to ensure that only one thread at a time can access the code that causes the problem; a process known as <i>synchronizing</i> that block of code.</p>
 
             <p>Synchronization works with locks. Every object comes with a built-in lock and since there is only lock per object, only one thread can hold that lock at any time. The other threads can only take the lock until the first thread release it. Meanwhile, they are blocked.</p>
 

--- a/ch27.html
+++ b/ch27.html
@@ -50,7 +50,7 @@
 
             <p>Synchronization works with locks. Every object comes with a built-in lock and since there is only lock per object, only one thread can hold that lock at any time. The other threads cannot take the lock until the first thread releases it. Meanwhile, they are blocked.</p>
 
-            <p>You acquire a lock by using the <code>synchronized</code> keyword in either a block or a method.</p>
+            <p>You define a lock by using the <code>synchronized</code> keyword on either a block or a method. That lock is acquired when a thread enters an unoccupied synchronized block or method.</p>
 
             <p>In a synchronized block, you use the <code>synchronized</code> keyword followed by either a reference variable:</p>
 
@@ -85,7 +85,7 @@
 	  &nbsp; &nbsp; }<br />
 	  }</code></p>
 
-            <p>Static code can also be synchronized but instead of using this to acquire the lock of an instance of the class, it is acquired on the class object that every class has associated:</p>
+            <p>Static code can also be synchronized but instead of using <code>this</code> to acquire the lock of an instance of the class, it is acquired on the single class object that every instance of the class has associated:</p>
 
             <p><code class="java hljs"><span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">MyClass</span></span> {<br />
 	  <span class="hljs-function"><span class="hljs-keyword">&nbsp; &nbsp; synchronized</span> <span class="hljs-keyword">static</span> <span class="hljs-keyword">void</span> <span class="hljs-title">method</span><span class="hljs-params">()</span></span> {<br />
@@ -93,7 +93,7 @@
 	  &nbsp; &nbsp; }<br />
 	  }</code></p>
 
-            <p>It's equivalent to:</p>
+            <p>Is equivalent to:</p>
 
             <p><code class="java hljs"><span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">MyClass</span></span> {<br />
 	  <span class="hljs-function"><span class="hljs-keyword">&nbsp; &nbsp; static</span> <span class="hljs-keyword">void</span> <span class="hljs-title">method</span><span class="hljs-params">()</span></span> {<br />

--- a/ch27.html
+++ b/ch27.html
@@ -50,7 +50,7 @@
 
             <p>Synchronization works with locks. Every object comes with a built-in lock and since there is only lock per object, only one thread can hold that lock at any time. The other threads cannot take the lock until the first thread releases it. Meanwhile, they are blocked.</p>
 
-            <p>You can define a lock by using the <code>synchronized</code> keyword in either a block or a method.</p>
+            <p>You acquire a lock by using the <code>synchronized</code> keyword in either a block or a method.</p>
 
             <p>In a synchronized block, you use the <code>synchronized</code> keyword followed by either a reference variable:</p>
 
@@ -85,7 +85,7 @@
 	  &nbsp; &nbsp; }<br />
 	  }</code></p>
 
-            <p>Static code can also be synchronized but instead of using this to acquire the lock of an instance of the class, it is acquired on the class object that every instance has associated:</p>
+            <p>Static code can also be synchronized but instead of using this to acquire the lock of an instance of the class, it is acquired on the class object that every class has associated:</p>
 
             <p><code class="java hljs"><span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">MyClass</span></span> {<br />
 	  <span class="hljs-function"><span class="hljs-keyword">&nbsp; &nbsp; synchronized</span> <span class="hljs-keyword">static</span> <span class="hljs-keyword">void</span> <span class="hljs-title">method</span><span class="hljs-params">()</span></span> {<br />

--- a/ch27.html
+++ b/ch27.html
@@ -561,7 +561,7 @@
 
 
 
-            <p>4. Under what circumstances can the <code>await()</code> method of <code>CyclicBarrier</code> throw an exception?<br /> A. If the thread goes to sleep<br /> B. When the last thread calls <code>await()</code><br /> C. If any thread is interrupted<br /> D. If the number of threads that call <code>await()</code> is different than the number of threads <code>CyclicBarrier</code> was created.</p>
+            <p>4. Under what circumstances can the <code>await()</code> method of <code>CyclicBarrier</code> throw an exception?<br /> A. If the thread goes to sleep<br /> B. When the last thread calls <code>await()</code><br /> C. If any thread is interrupted<br /> D. If the number of threads that call <code>await()</code> is different than the number of threads <code>CyclicBarrier</code> was created with.</p>
 
 
 

--- a/ch27.html
+++ b/ch27.html
@@ -511,7 +511,7 @@
 
             <h2>Self Test</h2>
 
-            <p>1. Which of the following statements is true?<br /> A. <code>ConcurrentNavigableMap</code> has two implementations, <code>ConcurrentSkipListMap</code> and <code>ConcurrentSkipListSet</code><br /> B. The <code>remove()</code> method of <code>CopyOnWriteArrayList</code> creates a new copy of the underlying array this class is based.<br /> C. A <code>static</code> method can acquire the lock of an instance variable.<br /> D. Constructors can be synchronized.</p>
+            <p>1. Which of the following statements is true?<br /> A. <code>ConcurrentNavigableMap</code> has two implementations, <code>ConcurrentSkipListMap</code> and <code>ConcurrentSkipListSet</code><br /> B. The <code>remove()</code> method of <code>CopyOnWriteArrayList</code> creates a new copy of the underlying array on which this class is based.<br /> C. A <code>static</code> method can acquire the lock of an instance variable.<br /> D. Constructors can be synchronized.</p>
 
 
 

--- a/ch27.html
+++ b/ch27.html
@@ -407,11 +407,11 @@
 
             <h2>CyclicBarrier</h2>
 
-            <p>The <code>synchronized</code> keyword help us to coordinate access by multiple threads to a shared resource.</p>
+            <p>The <code>synchronized</code> keyword helps us coordinate access to a shared resource by multiple threads.</p>
 
-            <p>But this work at a very low-level, I mean, it takes a lot of effort to coordinate complex concurrent tasks. Luckily, Java provides high-level classes to implement this kind of synchronization tasks easily.</p>
+            <p>But this is very low-level work. I mean, it takes a lot of effort to coordinate complex concurrent tasks. Luckily, Java provides high-level classes to more easily implement these kinds of synchronization tasks.</p>
 
-            <p>One of these classes is <code>CyclicBarrier</code> that provides a synchronization point (a barrier point) where a thread may need to wait until all other threads reach that point.</p>
+            <p>One of these classes is <code>CyclicBarrier</code>. It provides a synchronization point (a barrier point) where a thread may need to wait until all other threads also reach that point.</p>
 
             <p>This class has two constructors:</p>
 

--- a/ch27.html
+++ b/ch27.html
@@ -50,7 +50,7 @@
 
             <p>Synchronization works with locks. Every object comes with a built-in lock and since there is only lock per object, only one thread can hold that lock at any time. The other threads cannot take the lock until the first thread releases it. Meanwhile, they are blocked.</p>
 
-            <p>You acquire a lock by using the <code>synchronized</code> keyword in either a block or a method.</p>
+            <p>You can define a lock by using the <code>synchronized</code> keyword in either a block or a method.</p>
 
             <p>In a synchronized block, you use the <code>synchronized</code> keyword followed by either a reference variable:</p>
 

--- a/ch27.html
+++ b/ch27.html
@@ -561,7 +561,7 @@
 
 
 
-            <p>4. In which cases the <code>await()</code> method of <code>CyclicBarrier</code> can throw an exception?<br /> A. If the thread goes to sleep<br /> B. When the last thread calls <code>await()</code><br /> C. If any thread is interrupted<br /> D. If the number of threads that call <code>await()</code> is different than the number of threads <code>CyclicBarrier</code> was created.</p>
+            <p>4. Under what circumstances can the <code>await()</code> method of <code>CyclicBarrier</code> throw an exception?<br /> A. If the thread goes to sleep<br /> B. When the last thread calls <code>await()</code><br /> C. If any thread is interrupted<br /> D. If the number of threads that call <code>await()</code> is different than the number of threads <code>CyclicBarrier</code> was created.</p>
 
 
 

--- a/ch27.html
+++ b/ch27.html
@@ -85,7 +85,7 @@
 	  &nbsp; &nbsp; }<br />
 	  }</code></p>
 
-            <p>Static code can also be synchronized but instead of using this to acquire the lock of an instance of the class, it is acquired on the class object that every class has associated:</p>
+            <p>Static code can also be synchronized but instead of using this to acquire the lock of an instance of the class, it is acquired on the class object that every instance has associated:</p>
 
             <p><code class="java hljs"><span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">MyClass</span></span> {<br />
 	  <span class="hljs-function"><span class="hljs-keyword">&nbsp; &nbsp; synchronized</span> <span class="hljs-keyword">static</span> <span class="hljs-keyword">void</span> <span class="hljs-title">method</span><span class="hljs-params">()</span></span> {<br />

--- a/ch27a.html
+++ b/ch27a.html
@@ -39,7 +39,7 @@
 
             <h2>Answers</h2>
 
-            <p><b>1. The correct answer is B.</b><br /> Option A is false. <code>ConcurrentSkipListMap</code> is the only implementation of <code>ConcurrentNavigableMap</code>.<br /> Option B is true. Whenever there's a modification to a <code>CopyOnWriteArrayList</code> list, it creates a new copy of the underlying array.<br /> Option C is false. A <code>static</code> method can only use static variables, so it can only acquire the lock of static variables or the lock of variables defined inside the method.<br /> Option D is false. A constructor cannot be synchronized because only one thread has access to the object when is creating it.</p>
+            <p><b>1. The correct answer is B.</b><br /> Option A is false. <code>ConcurrentSkipListMap</code> is the only implementation of <code>ConcurrentNavigableMap</code>.<br /> Option B is true. Whenever there's a modification to a <code>CopyOnWriteArrayList</code> list, it creates a new copy of the underlying array.<br /> Option C is false. A <code>static</code> method can only use static variables, so it can only acquire the lock of static variables or the lock of variables defined inside the method.<br /> Option D is false. A constructor cannot be synchronized because only one thread has access to the object when it is being created.</p>
 
             <p><br /></p>
 


### PR DESCRIPTION
@eh3rrera The commits in this pull request should be uncontroversial. However, there are two points that I did not put in this PR, because I wanted to get your opinion. 

First, you say in the text "You acquire a lock by using the synchronized keyword in either a block or a method." I think it is more correct to say, "You define a lock by using the synchronized keyword...." and "You acquire a lock when a thread enters an unoccupied synchronized block or method."

And second, "Static code can also be synchronized but instead of using this to acquire the lock of an instance of the class, it is acquired on the class object that every class has associated." I think it is more correct to say "...it is acquired on the class object that every _instance_ has associated." I say this because a class does not have a class object... a class defines a class object. Each instance of a class has a class object. I think. lol.

What do you think?