### PR TITLE
Fix wrong method calls in chapter 29

### DIFF
--- a/ch29.html
+++ b/ch29.html
@@ -389,7 +389,7 @@
 	  <span class="hljs-comment">&nbsp; &nbsp;// Getting the date part</span><br />
 	  &nbsp; &nbsp;java.sql.Date sqlDate = rs.getDate(<span class="hljs-number">1</span>);<br />
 	  <span class="hljs-comment">&nbsp; &nbsp;// Getting the time part</span><br />
-	  &nbsp; &nbsp;java.sql.Time sqlTime = rs.getDate(<span class="hljs-number">1</span>);<br />
+	  &nbsp; &nbsp;java.sql.Time sqlTime = rs.getTime(<span class="hljs-number">1</span>);<br />
 	  <span class="hljs-comment">&nbsp; &nbsp;// Getting both, the date and time part</span><br />
 	  &nbsp; &nbsp;java.sql.Timestamp sqlTimestamp =<br />
 	  &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; rs.getTimestamp(<span class="hljs-number">1</span>);<br />

--- a/ch29.html
+++ b/ch29.html
@@ -364,7 +364,7 @@
             <p><code class="java hljs">Result rs = stmt.executeQuery(<br />
 	  <span class="hljs-string">&nbsp; &nbsp; &nbsp; "SELECT id, name FROM user"<br /></span>);<br />
 	  <span class="hljs-keyword">while</span>(rs.next()) {<br />
-	  <span class="hljs-keyword">&nbsp; &nbsp;int</span> id = rs.getString(<span class="hljs-string">"id"</span>);<br />
+	  <span class="hljs-keyword">&nbsp; &nbsp;int</span> id = rs.getInt(<span class="hljs-string">"id"</span>);<br />
 	  &nbsp; &nbsp;String name = rs.getString(<span class="hljs-string">"name"</span>);<br />
 	  <span class="hljs-comment">&nbsp; &nbsp;// Do something</span><br />
 	  }</code></p>
@@ -374,7 +374,7 @@
             <p><code class="java hljs">Result rs = stmt.executeQuery(<br />
 	  <span class="hljs-string">&nbsp; &nbsp; &nbsp; "SELECT id, name FROM user"<br /></span>);<br />
 	  <span class="hljs-keyword">while</span>(rs.next()) {<br />
-	  <span class="hljs-keyword">&nbsp; &nbsp;int</span> id = rs.getString(<span class="hljs-number">1</span>);<br />
+	  <span class="hljs-keyword">&nbsp; &nbsp;int</span> id = rs.getInt(<span class="hljs-number">1</span>);<br />
 	  &nbsp; &nbsp;String name = rs.getString(<span class="hljs-number">2</span>);<br />
 	  <span class="hljs-comment">&nbsp; &nbsp;// Do something</span><br />
 	  }</code></p>


### PR DESCRIPTION
Examples use `getString()` methods to retrieve `int` from `Result`, while they should use `getInt()` instead.

Another example uses `getDate()` to retrieve `java.sql.Time`, while it should use `getTime()`.